### PR TITLE
Add dependencies for caelestia

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,10 @@ build-backend = "hatchling.build"
 name = "caelestia"
 requires-python = ">=3.13"
 dynamic = ["version"]
+dependencies = [
+    "pillow",
+    "materialyoucolor"
+]
 
 [project.scripts]
 caelestia = "caelestia:main"


### PR DESCRIPTION
## Add Pillow and materialyoucolor as Project Dependencies

### Summary

This PR updates `pyproject.toml` to add `Pillow` and `materialyoucolor` as required dependencies for the project.

### Changes

- Added the following to `[project].dependencies` in `pyproject.toml`:
  - `pillow`
  - `materialyoucolor`

