### PR TITLE
wallpaper: fix random for multi-monitor setup

### DIFF
--- a/src/caelestia/utils/wallpaper.py
+++ b/src/caelestia/utils/wallpaper.py
@@ -48,12 +48,7 @@ def get_wallpapers(args: Namespace) -> list[Path]:
         return walls
 
     monitors = message("monitors")
-    filter_size = monitors[0]["width"], monitors[0]["height"]
-    for monitor in monitors[1:]:
-        if filter_size[0] > monitor["width"]:
-            filter_size[0] = monitor["width"]
-        if filter_size[1] > monitor["height"]:
-            filter_size[1] = monitor["height"]
+    filter_size = min(m["width"] for m in monitors), min(m["height"] for m in monitors)
 
     return [f for f in walls if check_wall(f, filter_size, args.threshold)]
 


### PR DESCRIPTION
This PR fixes #62 and does the samething as before, but allows it to be usable in multi-monitor setup. As I think this was never tested before on multi-monitor setups, it **may** have some kind of bug or drawback for **only** that using more than one monitor, but I've tested here and everything seems to be OK.

I don't know the base very well, but I think it's all right since does whats was intended when this code was written.