### PR TITLE
cli: quick fix to log-rules argument handling

### DIFF
--- a/src/caelestia/subcommands/shell.py
+++ b/src/caelestia/subcommands/shell.py
@@ -27,7 +27,7 @@ class Command:
             # Start the shell
             args = ["qs", "-c", "caelestia", "-n"]
             if self.args.log_rules:
-                args.append("--log-rules", self.args.log_rules)
+                args.extend(["--log-rules", self.args.log_rules])
             if self.args.daemon:
                 args.append("-d")
                 subprocess.run(args)


### PR DESCRIPTION
## Summary
Quick fix for argument handling when passing `--log-rules` to the process
```
args.append("--log-rules", self.args.log_rules)
```
would cause an error due to `append()` only accepting one item.

## Changes
Replaced `append()` with `extend()`

No breaking changes.

## Testing
- Ran `caelestia shell --log-rules "*=true"`
- Logs filtered as expected

## Notes
Simple one-liner change to restore log-rules behaviour