### PR TITLE
fix: ensure atomic writes for configuration files

### DIFF
--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -2,7 +2,8 @@ import json
 import re
 import subprocess
 from pathlib import Path
-import os
+import tempfile
+import shutil
 
 from caelestia.utils.colour import get_dynamic_colours
 from caelestia.utils.logging import log_exception
@@ -102,11 +103,11 @@ def gen_sequences(colours: dict[str, str]) -> str:
 
 def write_file(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    
-    temp_path = path.with_suffix('.tmp')
-    temp_path.write_text(content)
-    os.replace(temp_path, path)
 
+    with tempfile.NamedTemporaryFile("w") as f:
+        f.write(content)
+        f.flush()
+        shutil.move(f.name, path)
 
 @log_exception
 def apply_terms(sequences: str) -> None:


### PR DESCRIPTION
This PR addresses a race condition that occurs when themes are changed rapidly (using the Dynamic theme with frequent wallpaper updates).

The current write_file implementation is non-atomic. During rapid theme switching, Hyprland can trigger a reload while the file is still in this truncated or partially-written state, resulting in the configerrors below:

```
Config error in file /home/me/.config/hypr/hyprland/group.conf at line 5: Error parsing gradient rgba($onSurfaceVariant11): failed to parse rgba($onSurfaceVariant11) as a color

Config error in file /home/me/.config/hypr/hyprland/group.conf at line 18: rgb() expects length of 6 characters (3 bytes) or 3 comma separated values

Config error in file /home/me/.config/hypr/hyprland/group.conf at line 19: Error parsing gradient rgba($primaryd4): failed to parse rgba($primaryd4) as a color

Config error in file /home/me/.config/hypr/hyprland/group.conf at line 20: Error parsing gradient rgba($outlined4): failed to parse rgba($outlined4) as a color

Config error in file /home/me/.config/hypr/hyprland/group.conf at line 21: Error parsing gradient rgba($primaryd4): failed to parse rgba($primaryd4) as a color

Config error in file /home/me/.config/hypr/hyprland/group.conf at line 22: Error parsing gradient rgba($secondaryd4): failed to parse rgba($secondaryd4) as a color
```

