### PR TITLE
theme: gen_replace_dynamic accepts mode.

### DIFF
--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -52,7 +52,7 @@ def gen_replace_dynamic(colours: dict[str, str], template: Path, mode: str) -> s
     # match atomic {{ . }} pairs
     dotField = r"\{\{((?:(?!\{\{|\}\}).)*)\}\}"
 
-    #matches {{ mode }}
+    # match {{ mode }}
     modeField = r"\{\{\s*mode\s*\}\}"
 
     colours_dyn = get_dynamic_colours(colours)


### PR DESCRIPTION
* Some themes like those in NvChad require a mode to be supplied to work. Added a minimal change that makes apply_user_templates accept a mode parameter and replaces any {{ mode }} placeholder in a file with the actual mode.