### PR TITLE
theme: add Kitty terminal theme support

### DIFF
--- a/src/caelestia/data/templates/kitty.conf
+++ b/src/caelestia/data/templates/kitty.conf
@@ -1,0 +1,47 @@
+# Kitty Caelestia Color Config
+# Regenerated on scheme changes.
+# Include this file from kitty.conf to apply Caelestia colours.
+
+# Base colors
+foreground {{ $onSurface }}
+background {{ $surface }}
+
+# Cursor & selection
+cursor {{ $onSurface }}
+selection_foreground {{ $surface }}
+selection_background {{ $surfaceVariant }}
+
+# URL and marks
+url_color {{ $primary }}
+
+# Window borders & bell
+active_border_color {{ $primary }}
+inactive_border_color {{ $outline }}
+bell_border_color {{ $error }}
+
+# Tab bar
+active_tab_foreground {{ $onSurface }}
+active_tab_background {{ $surfaceVariant }}
+inactive_tab_foreground {{ $onSurfaceVariant }}
+inactive_tab_background {{ $surface }}
+tab_bar_background {{ $surfaceContainer }}
+tab_bar_margin_color {{ $surfaceContainerLowest }}
+
+# ANSI colors
+color0 {{ $term0 }}
+color1 {{ $term1 }}
+color2 {{ $term2 }}
+color3 {{ $term3 }}
+color4 {{ $term4 }}
+color5 {{ $term5 }}
+color6 {{ $term6 }}
+color7 {{ $term7 }}
+
+color8 {{ $term8 }}
+color9 {{ $term9 }}
+color10 {{ $term10 }}
+color11 {{ $term11 }}
+color12 {{ $term12 }}
+color13 {{ $term13 }}
+color14 {{ $term14 }}
+color15 {{ $term15 }}

--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -228,6 +228,17 @@ def apply_warp(colours: dict[str, str], mode: str) -> None:
 
 
 @log_exception
+def apply_kitty(colours: dict[str, str]) -> None:
+    template = gen_replace(colours, templates_dir / "kitty.conf", hash=True)
+    write_file(config_dir / "kitty/caelestia.conf", template)
+
+    subprocess.run(
+        ["kitty", "@", "set-colors", "--all", str(config_dir / "kitty/caelestia.conf")],
+        stderr=subprocess.DEVNULL,
+    )
+
+
+@log_exception
 def apply_cava(colours: dict[str, str]) -> None:
     template = gen_replace(colours, templates_dir / "cava.conf", hash=True)
     write_file(config_dir / "cava/config", template)
@@ -276,6 +287,8 @@ def apply_colours(colours: dict[str, str], mode: str) -> None:
         apply_qt(colours, mode)
     if check("enableWarp"):
         apply_warp(colours, mode)
+    if check("enableKitty"):
+        apply_kitty(colours)
     if check("enableCava"):
         apply_cava(colours)
     apply_user_templates(colours, mode)


### PR DESCRIPTION
## Summary 
- Add Kitty terminal theme support
- Integrate Kitty theming via template-based color generation
- Support live color reload via Kitty remote control
- Hook into main theme pipeline via `enableKitty` configuration

## Test Plan

- [x] Enable Kitty theming in configuration
- [x] Apply theme and verify `caelestia.conf` appears in `~/.config/kitty/`
- [x] Restart Kitty and confirm theme remains applied
- [x] Test light mode theme generation