### PR TITLE
record: add arg to copy screen recording to clipboard

### DIFF
--- a/completions/caelestia.fish
+++ b/completions/caelestia.fish
@@ -105,6 +105,7 @@ complete -c caelestia -n "$seen screenshot" -s 'f' -l 'freeze' -d 'Freeze while 
 # Record
 complete -c caelestia -n "$seen record" -s 'r' -l 'region' -d 'Capture region'
 complete -c caelestia -n "$seen record" -s 's' -l 'sound' -d 'Capture sound'
+complete -c caelestia -n "$seen record" -s 'c' -l 'clipboard' -d 'Copy recording path to clipboard'
 
 # Clipboard
 complete -c caelestia -n "$seen clipboard" -s 'd' -l 'delete' -d 'Delete from cliboard history'

--- a/src/caelestia/parser.py
+++ b/src/caelestia/parser.py
@@ -71,6 +71,7 @@ def parse_args() -> (argparse.ArgumentParser, argparse.Namespace):
     record_parser.add_argument("-r", "--region", nargs="?", const="slurp", help="record a region")
     record_parser.add_argument("-s", "--sound", action="store_true", help="record audio")
     record_parser.add_argument("-p", "--pause", action="store_true", help="pause/resume the recording")
+    record_parser.add_argument("-c", "--clipboard", action="store_true", help="copy recording path to clipboard")
 
     # Create parser for clipboard opts
     clipboard_parser = command_parser.add_parser("clipboard", help="open clipboard history")

--- a/src/caelestia/subcommands/record.py
+++ b/src/caelestia/subcommands/record.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import json
 import re
 import shutil
@@ -107,6 +108,10 @@ class Command:
             close_notification(recording_notif_path.read_text())
         except IOError:
             pass
+
+        if self.args.clipboard:
+            file_uri = Path(new_path).resolve().as_uri() + "\n"
+            subprocess.run(["wl-copy", "--type", "text/uri-list"], input=file_uri.encode())
 
         action = notify(
             "--action=watch=Watch",


### PR DESCRIPTION
This PR adds a flag to the `record` command that copies the recording's path as a URI to the clipboard.
This allows us to easily paste the file anywhere
```
caelestia record -c
```
or
```
caelestia record --clipboard
```