### PR TITLE
fix: apply mode substitution after dynamic template fill

### DIFF
--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -58,8 +58,8 @@ def gen_replace_dynamic(colours: dict[str, str], template: Path, mode: str) -> s
     colours_dyn = get_dynamic_colours(colours)
     template_content = template.read_text()
 
-    template_filled = re.sub(dotField, fill_colour, template_content) 
-    template_filled = re.sub(modeField, mode, template_content)
+    template_filled = re.sub(dotField, fill_colour, template_content)
+    template_filled = re.sub(modeField, mode, template_filled)
 
     return template_filled
 


### PR DESCRIPTION
## Changes
* gen_replace_dynamic() had a bug that wouldn't allow the user template to be updated
* template_filled is now **re.sub(modeField, mode, template_filled)** instead of **template_filled = re.sub(modeField, mode, template_content)**