### PR TITLE
nix: fix todoist command replacement in default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -68,7 +68,7 @@ python3.pkgs.buildPythonApplication {
     # Use config bin instead of discord + fix todoist + fix app2unit
     substituteInPlace src/caelestia/subcommands/toggle.py \
     	--replace-fail 'discord' ${discordBin} \
-      --replace-fail 'todoist' 'todoist.desktop'\
+      --replace-fail '["todoist"]' '["todoist.desktop"]'\
       --replace-fail 'app2unit' ${app2unit}/bin/app2unit
 
     # Use config style instead of darkly


### PR DESCRIPTION
Fixes a bug where the `todoist` configuration key was being renamed to `todoist.desktop` during the build, preventing users from disabling it in their config.

Fix:
Updated `default.nix` to target the command list `["todoist"]` specifically, rather than replacing every instance of the string "todoist".

Testing:
Verified locally via `nix build`. Confirmed that `src/caelestia/subcommands/toggle.py` in the result output retains the correct dictionary key while pointing to the correct desktop file.