### PR TITLE
theme: add live theming for chromium-based browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The main control script for the Caelestia dotfiles.
 <details><summary id="optional-dependencies">Optional dependencies</summary>
 
 - [`papirus-folders`](https://github.com/PapirusDevelopmentTeam/papirus-folders) - automatic folder icon color syncing with theme
+- Chromium-based browser (`chromium`, `brave`, or `google-chrome-stable`) - live browser theming
 
 > [!NOTE]
 > For automatic Papirus folder icon color syncing, `papirus-folders` needs to be able to run with `sudo` without a password prompt.
@@ -43,6 +44,22 @@ The main control script for the Caelestia dotfiles.
 >
 > ```
 > your_username ALL=(ALL) NOPASSWD: /usr/bin/papirus-folders
+> ```
+
+> [!NOTE]
+> For live Chromium-based browser theming, `mkdir` and `chmod` for browser policy directories need to be able to run with `sudo` without a password prompt.
+>
+> **Recommended** - Create a sudoers file:
+>
+> ```sh
+> echo "$USER ALL=(ALL) NOPASSWD: /usr/bin/mkdir, /usr/bin/chmod" | sudo tee /etc/sudoers.d/caelestia-chromium
+> sudo chmod 440 /etc/sudoers.d/caelestia-chromium
+> ```
+>
+> **Alternatively** - Edit the main sudoers file by running `sudo visudo` and adding at the end:
+>
+> ```
+> your_username ALL=(ALL) NOPASSWD: /usr/bin/mkdir, /usr/bin/chmod
 > ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -28,14 +28,7 @@ The main control script for the Caelestia dotfiles.
 >
 > **Recommended** - Create a sudoers file:
 >
-> ```fish
-> # Fish shell
-> echo "$USER ALL=(ALL) NOPASSWD: "(which papirus-folders) | sudo tee /etc/sudoers.d/papirus-folders
-> sudo chmod 440 /etc/sudoers.d/papirus-folders
-> ```
->
 > ```sh
-> # Bash/other shells
 > echo "$USER ALL=(ALL) NOPASSWD: $(which papirus-folders)" | sudo tee /etc/sudoers.d/papirus-folders
 > sudo chmod 440 /etc/sudoers.d/papirus-folders
 > ```
@@ -51,15 +44,22 @@ The main control script for the Caelestia dotfiles.
 >
 > **Recommended** - Create a sudoers file:
 >
-> ```sh
-> echo "$USER ALL=(ALL) NOPASSWD: /usr/bin/mkdir, /usr/bin/chmod" | sudo tee /etc/sudoers.d/caelestia-chromium
+> ```fish
+> # Fish shell
+> for dir in /etc/chromium/policies/managed /etc/brave/policies/managed /etc/opt/chrome/policies/managed
+>   echo "$USER ALL=(ALL) NOPASSWD: $(which mkdir) -p $dir" | sudo tee -a /etc/sudoers.d/caelestia-chromium
+>   echo "$USER ALL=(ALL) NOPASSWD: $(which tee) $dir/caelestia.json" | sudo tee -a /etc/sudoers.d/caelestia-chromium
+> end
 > sudo chmod 440 /etc/sudoers.d/caelestia-chromium
 > ```
 >
-> **Alternatively** - Edit the main sudoers file by running `sudo visudo` and adding at the end:
->
-> ```
-> your_username ALL=(ALL) NOPASSWD: /usr/bin/mkdir, /usr/bin/chmod
+> ```sh
+> # Bash/other shells
+> for dir in /etc/chromium/policies/managed /etc/brave/policies/managed /etc/opt/chrome/policies/managed; do
+>   echo "$USER ALL=(ALL) NOPASSWD: /usr/bin/mkdir -p $dir" | sudo tee -a /etc/sudoers.d/caelestia-chromium
+>   echo "$USER ALL=(ALL) NOPASSWD: /usr/bin/tee $dir/caelestia.json" | sudo tee -a /etc/sudoers.d/caelestia-chromium
+> done
+> sudo chmod 440 /etc/sudoers.d/caelestia-chromium
 > ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -18,52 +18,6 @@ The main control script for the Caelestia dotfiles.
 
 </details>
 
-<details><summary id="optional-dependencies">Optional dependencies</summary>
-
-- [`papirus-folders`](https://github.com/PapirusDevelopmentTeam/papirus-folders) - automatic folder icon color syncing with theme
-- Chromium-based browser (`chromium`, `brave`, or `google-chrome-stable`) - live browser theming
-
-> [!NOTE]
-> For automatic Papirus folder icon color syncing, `papirus-folders` needs to be able to run with `sudo` without a password prompt.
->
-> **Recommended** - Create a sudoers file:
->
-> ```sh
-> echo "$USER ALL=(ALL) NOPASSWD: $(which papirus-folders)" | sudo tee /etc/sudoers.d/papirus-folders
-> sudo chmod 440 /etc/sudoers.d/papirus-folders
-> ```
->
-> **Alternatively** - Edit the main sudoers file by running `sudo visudo` and adding at the end:
->
-> ```
-> your_username ALL=(ALL) NOPASSWD: /usr/bin/papirus-folders
-> ```
-
-> [!NOTE]
-> For live Chromium-based browser theming, `mkdir` and `chmod` for browser policy directories need to be able to run with `sudo` without a password prompt.
->
-> **Recommended** - Create a sudoers file:
->
-> ```fish
-> # Fish shell
-> for dir in /etc/chromium/policies/managed /etc/brave/policies/managed /etc/opt/chrome/policies/managed
->   echo "$USER ALL=(ALL) NOPASSWD: $(which mkdir) -p $dir" | sudo tee -a /etc/sudoers.d/caelestia-chromium
->   echo "$USER ALL=(ALL) NOPASSWD: $(which tee) $dir/caelestia.json" | sudo tee -a /etc/sudoers.d/caelestia-chromium
-> end
-> sudo chmod 440 /etc/sudoers.d/caelestia-chromium
-> ```
->
-> ```sh
-> # Bash/other shells
-> for dir in /etc/chromium/policies/managed /etc/brave/policies/managed /etc/opt/chrome/policies/managed; do
->   echo "$USER ALL=(ALL) NOPASSWD: /usr/bin/mkdir -p $dir" | sudo tee -a /etc/sudoers.d/caelestia-chromium
->   echo "$USER ALL=(ALL) NOPASSWD: /usr/bin/tee $dir/caelestia.json" | sudo tee -a /etc/sudoers.d/caelestia-chromium
-> done
-> sudo chmod 440 /etc/sudoers.d/caelestia-chromium
-> ```
-
-</details>
-
 ## Installation
 
 ### Arch linux
@@ -139,6 +93,45 @@ sudo python -m installer dist/*.whl
 sudo cp completions/caelestia.fish /usr/share/fish/vendor_completions.d/caelestia.fish
 ```
 
+### Additional steps
+
+#### Auto folder colour theming
+
+For automatic Papirus folder icon colour syncing, you must have [`papirus-folders`](https://github.com/PapirusDevelopmentTeam/papirus-folders)
+installed, and `papirus-folders` must to be able to run with `sudo` without a password prompt.
+
+You can allow this by creating a sudoers file:
+
+```sh
+echo "$USER ALL=(ALL) NOPASSWD: $(which papirus-folders)" | sudo tee /etc/sudoers.d/papirus-folders
+sudo chmod 440 /etc/sudoers.d/papirus-folders
+```
+
+#### Chromium-based browser theming
+
+For live Chromium-based browser theming, the CLI must be allowed to create certain directories in `/etc`
+and write to them via `sudo` without a password prompt.
+
+You can allow this by creating a sudoers file:
+
+```fish
+# Fish shell
+for dir in /etc/chromium/policies/managed /etc/brave/policies/managed /etc/opt/chrome/policies/managed
+    echo "$USER ALL=(ALL) NOPASSWD: $(which mkdir) -p $dir" | sudo tee -a /etc/sudoers.d/caelestia-chromium
+    echo "$USER ALL=(ALL) NOPASSWD: $(which tee) $dir/caelestia.json" | sudo tee -a /etc/sudoers.d/caelestia-chromium
+end
+sudo chmod 440 /etc/sudoers.d/caelestia-chromium
+```
+
+```sh
+# Bash/other shells
+for dir in /etc/chromium/policies/managed /etc/brave/policies/managed /etc/opt/chrome/policies/managed; do
+    echo "$USER ALL=(ALL) NOPASSWD: $(which mkdir) -p $dir" | sudo tee -a /etc/sudoers.d/caelestia-chromium
+    echo "$USER ALL=(ALL) NOPASSWD: $(which tee) $dir/caelestia.json" | sudo tee -a /etc/sudoers.d/caelestia-chromium
+done
+sudo chmod 440 /etc/sudoers.d/caelestia-chromium
+```
+
 ## Usage
 
 All subcommands/options can be explored via the help flag.
@@ -168,7 +161,7 @@ subcommands:
     resizer      window resizer daemon
 ```
 
-### User Templates
+### User templates
 
 Custom user templates can be defined in `~/.config/caelestia/templates/`.
 

--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -1,6 +1,5 @@
 import fcntl
 import json
-import os
 import re
 import shutil
 import subprocess
@@ -347,19 +346,31 @@ def apply_chromium(colours: dict[str, str]) -> None:
         ("brave", Path("/etc/brave/policies/managed")),
         ("google-chrome-stable", Path("/etc/opt/chrome/policies/managed")),
     ]
+
     for cmd, policy_dir in browsers:
         if shutil.which(cmd) is None:
             continue
         if not policy_dir.is_dir():
             subprocess.run(["sudo", "-n", "mkdir", "-p", str(policy_dir)], stderr=subprocess.DEVNULL)
-            subprocess.run(["sudo", "-n", "chmod", "a+rw", str(policy_dir)], stderr=subprocess.DEVNULL)
-        if not policy_dir.is_dir() or not os.access(policy_dir, os.W_OK):
+        if not policy_dir.is_dir():
+            print(f"Unable to create {policy_dir} directory")
             continue
-        write_file(policy_dir / "caelestia.json", json.dumps({"BrowserThemeColor": theme_color, "BrowserColorScheme": "device"}))
+
+        # Use tee instead of write_file cause we need sudo
+        subprocess.run(
+            ["sudo", "-n", "tee", str(policy_dir / "caelestia.json")],
+            input=json.dumps({"BrowserThemeColor": theme_color, "BrowserColorScheme": "device"}),
+            text=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         subprocess.run(
             [cmd, "--refresh-platform-policy", "--no-startup-window"],
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
+
+
 def apply_zed(colours: dict[str, str], mode: str) -> None:
     theme_path = config_dir / "zed/themes/caelestia.json"
     # Zed's file watcher does not detect changes through symlinks,

--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -1,11 +1,10 @@
 import fcntl
 import json
+import os
 import re
 import shutil
 import subprocess
 import tempfile
-import shutil
-import fcntl
 from pathlib import Path
 
 from caelestia.utils.colour import get_dynamic_colours
@@ -340,6 +339,30 @@ def apply_warp(colours: dict[str, str], mode: str) -> None:
 
 
 @log_exception
+def apply_chromium(colours: dict[str, str]) -> None:
+    surface_hex = colours["surface"]
+    theme_color = f"#{surface_hex}"
+    browsers = [
+        ("chromium", Path("/etc/chromium/policies/managed")),
+        ("brave", Path("/etc/brave/policies/managed")),
+        ("google-chrome-stable", Path("/etc/opt/chrome/policies/managed")),
+    ]
+    for cmd, policy_dir in browsers:
+        if shutil.which(cmd) is None:
+            continue
+        if not policy_dir.is_dir():
+            subprocess.run(["sudo", "-n", "mkdir", "-p", str(policy_dir)], stderr=subprocess.DEVNULL)
+            subprocess.run(["sudo", "-n", "chmod", "a+rw", str(policy_dir)], stderr=subprocess.DEVNULL)
+        if not policy_dir.is_dir() or not os.access(policy_dir, os.W_OK):
+            continue
+        write_file(policy_dir / "caelestia.json", json.dumps({"BrowserThemeColor": theme_color, "BrowserColorScheme": "device"}))
+        subprocess.run(
+            [cmd, "--refresh-platform-policy", "--no-startup-window"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+
+
+@log_exception
 def apply_cava(colours: dict[str, str]) -> None:
     template = gen_replace(colours, templates_dir / "cava.conf", hash=True)
     write_file(config_dir / "cava/config", template)
@@ -401,6 +424,8 @@ def apply_colours(colours: dict[str, str], mode: str) -> None:
                 apply_qt(colours, mode)
             if check("enableWarp"):
                 apply_warp(colours, mode)
+            if check("enableChromium"):
+                apply_chromium(colours)
             if check("enableCava"):
                 apply_cava(colours)
             apply_user_templates(colours, mode)


### PR DESCRIPTION
Currently there is no way to apply the Caelestia theme to Chromium-based browsers — only Firefox-based ones get live theming. After some digging, I found that Chrome managed policies can set theme colors, and starting from Chrome 142+ there is a new `--refresh-platform-policy` flag that forces the browser to immediately reload and apply policies without the usual delay. This makes true live theming possible.

This PR adds an `apply_chromium` function that deploys the surface colour as a `BrowserThemeColor` managed policy for Chromium, Brave, and Google Chrome Stable. When a wallpaper change triggers a theme update, the browser picks up the new color instantly.

**One-time setup required** — `mkdir` and `chmod` for browser policy directories need to be able to run with `sudo` without a password prompt

```sh
echo "$USER ALL=(ALL) NOPASSWD: /usr/bin/mkdir, /usr/bin/chmod" | sudo tee /etc/sudoers.d/caelestia-chromium
sudo chmod 440 /etc/sudoers.d/caelestia-chromium
```

Alternatively, edit the main sudoers file by running `sudo visudo` and adding at the end:
```
your_username ALL=(ALL) NOPASSWD: /usr/bin/mkdir, /usr/bin/chmod
```

This allows the CLI to automatically create and set permissions on the policy directories (`/etc/chromium/policies/managed`, `/etc/brave/policies/managed`, `/etc/opt/chrome/policies/managed`) on first run without prompting for a password.

Enabled via `enableChromium` in the theme config (defaults to true like other integrations).