### PR TITLE
theme: allow overriding Qt icon theme via cli.json

### DIFF
--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -319,12 +319,14 @@ def apply_gtk(colours: dict[str, str], mode: str) -> None:
 
 
 @log_exception
-def apply_qt(colours: dict[str, str], mode: str) -> None:
+def apply_qt(colours: dict[str, str], mode: str, icon_theme: str | None = None) -> None:
     colours = gen_replace(colours, templates_dir / f"qt{mode}.colors", hash=True)
     write_file(config_dir / "qtengine/caelestia.colors", colours)
 
     config = (templates_dir / "qtengine.json").read_text()
     config = config.replace("{{ $mode }}", mode.capitalize())
+    if icon_theme is not None:
+        config = config.replace(f'"iconTheme": "Papirus-{mode.capitalize()}"', f'"iconTheme": "{icon_theme}"')
     write_file(config_dir / "qtengine/config.json", config)
 
 
@@ -441,7 +443,7 @@ def apply_colours(colours: dict[str, str], mode: str) -> None:
             if check("enableGtk"):
                 apply_gtk(colours, mode)
             if check("enableQt"):
-                apply_qt(colours, mode)
+                apply_qt(colours, mode, cfg.get("iconTheme"))
             if check("enableWarp"):
                 apply_warp(colours, mode)
             if check("enableChromium"):


### PR DESCRIPTION
## What this does

Adds an optional `iconTheme` field to the `theme` section of `cli.json`. When set, it overrides the Papirus icon theme in the generated `qtengine/config.json`.

## Problem

This is specifically visible in Dolphin. With Papirus set as the icon theme in qtengine, some folders end up with Papirus-style icons while others use the default theme icons - resulting in two different icon styles mixed together in the same view.

This happens because some icon names (like `folder-downloads`, `folder-pictures`, etc.) are resolved differently depending on the theme fallback chain. XDG special folders and folders that have a `.desktop` file inside them tend to pick up Papirus icons, while regular folders stay on the default theme.

The reason to prefer a different icon theme here is that Dolphin's default folder icons take their color directly from the active color scheme - so they always match the theme exactly and look consistent with each other. Papirus has a fixed, limited palette and does not always match.

**Before** - mixed folder styles in Dolphin:
<img width="1271" height="887" alt="image" src="https://github.com/user-attachments/assets/40e99a81-9b1f-4771-9a45-431d227eab06" />


**After** - consistent folders:
<img width="1223" height="974" alt="image" src="https://github.com/user-attachments/assets/6abd15e5-f640-4967-a929-33d60f4e193b" />
## Solution

One field in `cli.json`:

```json
"theme": {
    "iconTheme": "breeze-dark"
}
```

If `iconTheme` is not set, behavior is unchanged - Papirus is used as before.

## Changes

- `apply_qt` accepts an optional `icon_theme: str | None = None` parameter
- if provided, replaces the `iconTheme` value in the generated qtengine config
- `apply_colours` passes `cfg.get("iconTheme")` to `apply_qt`

## Testing

Tested locally by setting `"iconTheme": "breeze-dark"` in `cli.json` and running `caelestia scheme set -n dynamic -m dark` - the generated `~/.config/qtengine/config.json` correctly contained `"iconTheme": "breeze-dark"` instead of `"iconTheme": "Papirus-Dark"`.