### PR TITLE
theme: allow overriding Qt icon theme via cli.json

### DIFF
--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -319,12 +319,14 @@ def apply_gtk(colours: dict[str, str], mode: str) -> None:
 
 
 @log_exception
-def apply_qt(colours: dict[str, str], mode: str) -> None:
+def apply_qt(colours: dict[str, str], mode: str, icon_theme: str | None = None) -> None:
     colours = gen_replace(colours, templates_dir / f"qt{mode}.colors", hash=True)
     write_file(config_dir / "qtengine/caelestia.colors", colours)
 
     config = (templates_dir / "qtengine.json").read_text()
     config = config.replace("{{ $mode }}", mode.capitalize())
+    if icon_theme is not None:
+        config = config.replace(f'"iconTheme": "Papirus-{mode.capitalize()}"', f'"iconTheme": "{icon_theme}"')
     write_file(config_dir / "qtengine/config.json", config)
 
 
@@ -441,7 +443,7 @@ def apply_colours(colours: dict[str, str], mode: str) -> None:
             if check("enableGtk"):
                 apply_gtk(colours, mode)
             if check("enableQt"):
-                apply_qt(colours, mode)
+                apply_qt(colours, mode, cfg.get("iconTheme"))
             if check("enableWarp"):
                 apply_warp(colours, mode)
             if check("enableChromium"):

--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -302,7 +302,7 @@ def _determine_hue_color(r: int, g: int, b: int, brightness: int, use_pale: bool
 
 
 @log_exception
-def apply_gtk(colours: dict[str, str], mode: str) -> None:
+def apply_gtk(colours: dict[str, str], mode: str, icon_theme: str | None = None) -> None:
     gtk_template = gen_replace(colours, templates_dir / "gtk.css", hash=True)
     thunar_template = gen_replace(colours, templates_dir / "thunar.css", hash=True)
 
@@ -313,7 +313,8 @@ def apply_gtk(colours: dict[str, str], mode: str) -> None:
 
     subprocess.run(["dconf", "write", "/org/gnome/desktop/interface/gtk-theme", "'adw-gtk3-dark'"])
     subprocess.run(["dconf", "write", "/org/gnome/desktop/interface/color-scheme", f"'prefer-{mode}'"])
-    subprocess.run(["dconf", "write", "/org/gnome/desktop/interface/icon-theme", f"'Papirus-{mode.capitalize()}'"])
+    gtk_icon_theme = icon_theme if icon_theme is not None else f"Papirus-{mode.capitalize()}"
+    subprocess.run(["dconf", "write", "/org/gnome/desktop/interface/icon-theme", f"'{gtk_icon_theme}'"])
 
     sync_papirus_colors(colours["primary"])
 
@@ -440,10 +441,11 @@ def apply_colours(colours: dict[str, str], mode: str) -> None:
                 apply_nvtop(colours)
             if check("enableHtop"):
                 apply_htop(colours)
+            icon_theme = cfg.get(f"iconTheme{mode.capitalize()}") or cfg.get("iconTheme")
             if check("enableGtk"):
-                apply_gtk(colours, mode)
+                apply_gtk(colours, mode, icon_theme)
             if check("enableQt"):
-                apply_qt(colours, mode, cfg.get("iconTheme"))
+                apply_qt(colours, mode, icon_theme)
             if check("enableWarp"):
                 apply_warp(colours, mode)
             if check("enableChromium"):


### PR DESCRIPTION
## What this does

Adds optional `iconThemeDark` and `iconThemeLight` fields to the `theme` section of `cli.json`. When set, they override the Papirus icon theme for both Qt apps (via qtengine) and GTK apps (via dconf). A generic `iconTheme` field is also supported as a fallback for both modes.

## Problem

This is specifically visible in Dolphin. With Papirus set as the icon theme in qtengine, some folders end up with Papirus-style icons while others use the default theme icons - resulting in two different icon styles mixed together in the same view.

This happens because some icon names (like `folder-downloads`, `folder-pictures`, etc.) are resolved differently depending on the theme fallback chain. XDG special folders and folders that have a `.desktop` file inside them tend to pick up Papirus icons, while regular folders stay on the default theme.

The deeper reason to prefer a different icon theme here is that Dolphin's default folder icons take their color directly from the active color scheme - so they always match the theme exactly and look consistent with each other. Papirus has a fixed, limited palette and does not always match.

**Before** - mixed folder styles in Dolphin:
<img width="1271" height="887" alt="image" src="https://github.com/user-attachments/assets/2ab60ed5-a197-48d4-b267-80a0374fa08b" />

**After** - consistent folders:
<img width="1223" height="974" alt="image" src="https://github.com/user-attachments/assets/4acda1b1-b0ea-4053-9fa0-5792e54475a6" />

## Solution

```json
"theme": {
    "iconThemeDark": "breeze-dark",
    "iconThemeLight": "breeze"
}
```

A generic `iconTheme` is also accepted as a fallback for both modes. If none of these are set, behavior is unchanged - Papirus is used as before.

## Changes

- `apply_gtk` accepts an optional `icon_theme: str | None = None` parameter and uses it for the dconf icon-theme setting
- `apply_qt` accepts an optional `icon_theme: str | None = None` parameter and uses it in the qtengine config
- `apply_colours` resolves the icon theme from `iconThemeDark`/`iconThemeLight` (with `iconTheme` as fallback) and passes it to both functions

## Testing

Tested locally by setting `"iconThemeDark": "breeze-dark"` in `cli.json` and running `caelestia scheme set -n dynamic -m dark` - the generated `~/.config/qtengine/config.json` correctly contained `"iconTheme": "breeze-dark"` and `gsettings get org.gnome.desktop.interface icon-theme` returned `breeze-dark`.

Also works for GTK apps and switches between dark and light theme
<img width="468" height="396" alt="image" src="https://github.com/user-attachments/assets/a940dca0-12ea-40c9-a27b-cc9c092bdf9a" /> 
<img width="448" height="329" alt="image" src="https://github.com/user-attachments/assets/d65b2c5c-ba81-4cd3-93ff-f3473ba3226e" />

