### PR TITLE
fix: Lua dispatcher compat

### DIFF
--- a/src/caelestia/subcommands/resizer.py
+++ b/src/caelestia/subcommands/resizer.py
@@ -46,7 +46,6 @@ class Command:
             return "dispatch hl.dsp.window.center()"
         return "dispatch centerwindow"
 
-
     def _load_window_rules(self) -> list[WindowRule]:
         default_rules = [
             WindowRule("(Bitwarden", "titleContains", "20%", "54%", ["float", "center"]),
@@ -188,7 +187,6 @@ class Command:
             command1 = self._make_resize_cmd(scaled_width, scaled_height, address)
             command2 = self._make_move_cmd(int(move_x), int(move_y), address)
             hypr.batch(command1, command2)
-
 
             log_message(
                 f"Applied PiP action to window {address}: {scaled_width}x{scaled_height} at ({move_x}, {move_y})"

--- a/src/caelestia/subcommands/resizer.py
+++ b/src/caelestia/subcommands/resizer.py
@@ -26,6 +26,27 @@ class Command:
         self.timeout_tracker: dict[str, float] = {}
         self.window_rules = self._load_window_rules()
 
+    def _make_resize_cmd(self, width: int | str, height: int | str, address: str) -> str:
+        if hypr.is_lua_config():
+            return f'dispatch hl.dsp.window.resize({{x = {width}, y = {height}, exact = true, window = "address:{address}"}})'
+        return f"dispatch resizewindowpixel exact {width} {height},address:{address}"
+
+    def _make_move_cmd(self, x: int, y: int, address: str) -> str:
+        if hypr.is_lua_config():
+            return f'dispatch hl.dsp.window.move({{x = {x}, y = {y}, window = "address:{address}"}})'
+        return f"dispatch movewindowpixel exact {x} {y},address:{address}"
+
+    def _make_float_cmd(self, address: str) -> str:
+        if hypr.is_lua_config():
+            return f'dispatch hl.dsp.window.float({{action = "toggle", window = "address:{address}"}})'
+        return f"dispatch togglefloating address:{address}"
+
+    def _make_center_cmd(self) -> str:
+        if hypr.is_lua_config():
+            return "dispatch hl.dsp.window.center()"
+        return "dispatch centerwindow"
+
+
     def _load_window_rules(self) -> list[WindowRule]:
         default_rules = [
             WindowRule("(Bitwarden", "titleContains", "20%", "54%", ["float", "center"]),
@@ -164,9 +185,10 @@ class Command:
             move_x = monitor_x + monitor_width - scaled_width - offset
             move_y = monitor_y + monitor_height - scaled_height - offset
 
-            command1 = f"dispatch resizewindowpixel exact {scaled_width} {scaled_height},address:{address}"
-            command2 = f"dispatch movewindowpixel exact {int(move_x)} {int(move_y)},address:{address}"
+            command1 = self._make_resize_cmd(scaled_width, scaled_height, address)
+            command2 = self._make_move_cmd(int(move_x), int(move_y), address)
             hypr.batch(command1, command2)
+
 
             log_message(
                 f"Applied PiP action to window {address}: {scaled_width}x{scaled_height} at ({move_x}, {move_y})"
@@ -181,16 +203,16 @@ class Command:
         if "float" in actions:
             window_info = self._get_window_info(window_id)
             if window_info and not window_info.get("floating", False):
-                dispatch_commands.append(f"dispatch togglefloating address:0x{window_id}")
+                dispatch_commands.append(self._make_float_cmd(f"0x{window_id}"))
 
         if "pip" in actions:
             self._apply_pip_action(window_id)
             return True
 
-        dispatch_commands.append(f"dispatch resizewindowpixel exact {width} {height},address:0x{window_id}")
+        dispatch_commands.append(self._make_resize_cmd(width, height, f"0x{window_id}"))
 
         if "center" in actions:
-            dispatch_commands.append("dispatch centerwindow")
+            dispatch_commands.append(self._make_center_cmd())
 
         try:
             hypr.batch(*dispatch_commands)

--- a/src/caelestia/subcommands/toggle.py
+++ b/src/caelestia/subcommands/toggle.py
@@ -160,5 +160,7 @@ class Command:
         monitors = cast(list[dict[str, Any]], hypr.message("monitors"))
         target = next((m for m in monitors if m.get("focused")), None)
         if target:
-            special = target.get("specialWorkspace", {}).get("name", "")[8:] or "special"
-            hypr.dispatch("togglespecialworkspace", special)
+            special = target.get("specialWorkspace", {}).get("name", "")[8:]
+            if special and special != "special":
+                hypr.dispatch("togglespecialworkspace", special)
+            hypr.dispatch("togglespecialworkspace", "special")

--- a/src/caelestia/subcommands/toggle.py
+++ b/src/caelestia/subcommands/toggle.py
@@ -160,7 +160,5 @@ class Command:
         monitors = cast(list[dict[str, Any]], hypr.message("monitors"))
         target = next((m for m in monitors if m.get("focused")), None)
         if target:
-            special = target.get("specialWorkspace", {}).get("name", "")[8:]
-            if special and special != "special":
-                hypr.dispatch("togglespecialworkspace", special)
-            hypr.dispatch("togglespecialworkspace", "special")
+            special = target.get("specialWorkspace", {}).get("name", "")[8:] or "special"
+            hypr.dispatch("togglespecialworkspace", special)

--- a/src/caelestia/utils/hypr.py
+++ b/src/caelestia/utils/hypr.py
@@ -26,7 +26,30 @@ def message(msg: str, is_json: bool = True) -> str | dict[str, Any]:
         return json.loads(resp) if is_json else resp
 
 
+def _is_lua_config() -> bool:
+    try:
+        result = message("systeminfo", is_json=False)
+        for line in result.splitlines():
+            if "configProvider:" in line:
+                return "lua" in line.lower()
+        return False
+    except Exception:
+        return False
+
+
+DISPATCHER_MAP_LUA = {
+    "togglespecialworkspace": lambda *a: f'hl.dsp.workspace.toggle_special("{a[0]}")' if a else 'hl.dsp.workspace.toggle_special()',
+    "movetoworkspacesilent": lambda *a: (
+    f'hl.dsp.window.move({{window = "address:{a[0].split(",")[1].replace("address:", "")}", workspace = "{a[0].split(",")[0]}", follow = false}})'
+),
+    "exec": lambda *a: 'hl.dsp.exec_cmd("' + ' '.join(a).replace('\\', '\\\\').replace('"', '\\"') + '")',
+}
+
+
 def dispatch(dispatcher: str, *args: str) -> bool:
+    if _is_lua_config() and dispatcher in DISPATCHER_MAP_LUA:
+        lua_dispatch = DISPATCHER_MAP_LUA[dispatcher](*args)
+        return message(f"dispatch {lua_dispatch}", is_json=False) == "ok"
     return message(f"dispatch {dispatcher} {' '.join(map(str, args))}".rstrip(), is_json=False) == "ok"
 
 

--- a/src/caelestia/utils/hypr.py
+++ b/src/caelestia/utils/hypr.py
@@ -7,6 +7,7 @@ socket_base = f"{os.getenv('XDG_RUNTIME_DIR')}/hypr/{os.getenv('HYPRLAND_INSTANC
 socket_path = f"{socket_base}/.socket.sock"
 socket2_path = f"{socket_base}/.socket2.sock"
 
+_lua_config_cache: bool | None = None
 
 def message(msg: str, is_json: bool = True) -> str | dict[str, Any]:
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
@@ -26,18 +27,21 @@ def message(msg: str, is_json: bool = True) -> str | dict[str, Any]:
         return json.loads(resp) if is_json else resp
 
 
-def _is_lua_config() -> bool:
+def is_lua_config() -> bool:
+    global _lua_config_cache
+    if _lua_config_cache is not None:
+        return _lua_config_cache
     try:
         result = message("systeminfo", is_json=False)
         for line in result.splitlines():
             if "configProvider:" in line:
-                return "lua" in line.lower()
+                _lua_config_cache = "lua" in line.lower()
+                return _lua_config_cache
+        _lua_config_cache = False
         return False
     except Exception:
+        _lua_config_cache = False
         return False
-
-def is_lua_config() -> bool:
-    return _is_lua_config()
 
 
 DISPATCHER_MAP_LUA = {
@@ -50,7 +54,7 @@ DISPATCHER_MAP_LUA = {
 
 
 def dispatch(dispatcher: str, *args: str) -> bool:
-    if _is_lua_config() and dispatcher in DISPATCHER_MAP_LUA:
+    if is_lua_config() and dispatcher in DISPATCHER_MAP_LUA:
         lua_dispatch = DISPATCHER_MAP_LUA[dispatcher](*args)
         return message(f"dispatch {lua_dispatch}", is_json=False) == "ok"
     return message(f"dispatch {dispatcher} {' '.join(map(str, args))}".rstrip(), is_json=False) == "ok"

--- a/src/caelestia/utils/hypr.py
+++ b/src/caelestia/utils/hypr.py
@@ -36,6 +36,9 @@ def _is_lua_config() -> bool:
     except Exception:
         return False
 
+def is_lua_config() -> bool:
+    return _is_lua_config()
+
 
 DISPATCHER_MAP_LUA = {
     "togglespecialworkspace": lambda *a: f'hl.dsp.workspace.toggle_special("{a[0]}")' if a else 'hl.dsp.workspace.toggle_special()',

--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -28,9 +28,10 @@ def gen_conf(colours: dict[str, str]) -> str:
     return conf
 
 def gen_lua(colours: dict[str, str]) -> str:
-    lua = ""
+    lua = "return {\n"
     for name, colour in colours.items():
-        lua += f'{name} = "{colour}"\n'
+        lua += f'  {name} = "{colour}",\n'
+    lua += "}"
     return lua
 
 def gen_scss(colours: dict[str, str]) -> str:

--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -19,6 +19,7 @@ from caelestia.utils.paths import (
     user_templates_dir,
 )
 from caelestia.utils.scheme import get_scheme
+from caelestia.utils.hypr import is_lua_config
 
 
 def gen_conf(colours: dict[str, str]) -> str:
@@ -150,11 +151,8 @@ def apply_terms(sequences: str) -> None:
 
 @log_exception
 def apply_hypr(conf: str) -> None:
-    from caelestia.utils.hypr import is_lua_config
-    if is_lua_config():
-        write_file(config_dir / "hypr/scheme/current.lua", conf)
-    else:
-        write_file(config_dir / "hypr/scheme/current.conf", conf)
+    ext = "lua" if is_lua_config() else "conf"
+    write_file(config_dir / f"hypr/scheme/current.{ext}", conf)
 
 
 @log_exception
@@ -438,11 +436,7 @@ def apply_colours(colours: dict[str, str], mode: str) -> None:
             if check("enableTerm"):
                 apply_terms(gen_sequences(colours))
             if check("enableHypr"):
-                from caelestia.utils.hypr import is_lua_config
-                if is_lua_config():
-                    apply_hypr(gen_lua(colours))
-                else:
-                    apply_hypr(gen_conf(colours))
+                apply_hypr(gen_lua(colours) if is_lua_config() else gen_conf(colours))
             if check("enableDiscord"):
                 apply_discord(gen_scss(colours))
             if check("enableSpicetify"):

--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -27,6 +27,11 @@ def gen_conf(colours: dict[str, str]) -> str:
         conf += f"${name} = {colour}\n"
     return conf
 
+def gen_lua(colours: dict[str, str]) -> str:
+    lua = ""
+    for name, colour in colours.items():
+        lua += f'{name} = "{colour}"\n'
+    return lua
 
 def gen_scss(colours: dict[str, str]) -> str:
     scss = ""
@@ -144,7 +149,11 @@ def apply_terms(sequences: str) -> None:
 
 @log_exception
 def apply_hypr(conf: str) -> None:
-    write_file(config_dir / "hypr/scheme/current.conf", conf)
+    from caelestia.utils.hypr import is_lua_config
+    if is_lua_config():
+        write_file(config_dir / "hypr/scheme/current.lua", conf)
+    else:
+        write_file(config_dir / "hypr/scheme/current.conf", conf)
 
 
 @log_exception
@@ -428,7 +437,11 @@ def apply_colours(colours: dict[str, str], mode: str) -> None:
             if check("enableTerm"):
                 apply_terms(gen_sequences(colours))
             if check("enableHypr"):
-                apply_hypr(gen_conf(colours))
+                from caelestia.utils.hypr import is_lua_config
+                if is_lua_config():
+                    apply_hypr(gen_lua(colours))
+                else:
+                    apply_hypr(gen_conf(colours))
             if check("enableDiscord"):
                 apply_discord(gen_scss(colours))
             if check("enableSpicetify"):


### PR DESCRIPTION
Hyprland 0.55 deprecated hyprlang in favor of Lua, introducing breaking changes to dispatcher syntax and config file formats. This PR adds full backward compatibility for both `.conf` and `.lua` configs by detecting the active config provider via `hyprctl systeminfo` and transparently mapping legacy dispatcher calls to their Lua equivalents across `hypr.py`, `toggle.py`, `resizer.py`, and `theme.py`. Existing hyprlang setups are unaffected.