### PR TITLE
feat: apply spicetify theme to running Spotify on scheme change

### DIFF
--- a/src/caelestia/utils/theme.py
+++ b/src/caelestia/utils/theme.py
@@ -178,6 +178,10 @@ def apply_pandora(colours: dict[str, str], mode: str) -> None:
 def apply_spicetify(colours: dict[str, str], mode: str) -> None:
     template = gen_replace(colours, templates_dir / f"spicetify-{mode}.ini")
     write_file(config_dir / "spicetify/Themes/caelestia/color.ini", template)
+    # Push the new colours into a running Spotify. Only attempt this if Spicetify
+    # is actually installed, so users without it are unaffected.
+    if shutil.which("spicetify"):
+        subprocess.run(["spicetify", "apply"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
 @log_exception


### PR DESCRIPTION
## What

`apply_spicetify()` regenerates `spicetify/Themes/caelestia/color.ini` on every scheme change, but a running Spotify isn't repainted unless a `spicetify watch -s` process happens to be running (currently only started via `caelestia toggle music`). If Spotify is launched any other way, its colours stay frozen at whatever they were when `spicetify apply` last ran, so they don't track the wallpaper/scheme.

This adds a one-shot `spicetify apply` after writing `color.ini`, so the running client picks up the new colours regardless of how it was launched.

## Safety

Guarded with `shutil.which("spicetify")` so users without Spicetify installed are completely unaffected — no new behaviour, no errors. Output is discarded. The call is already inside `@log_exception`, so a failure won't break the rest of `apply_colours`.