### PR TITLE
fix: prevent version command crash when local shell copy is not a git repository

### DIFF
--- a/src/caelestia/utils/version.py
+++ b/src/caelestia/utils/version.py
@@ -49,29 +49,34 @@ def print_version() -> None:
     local_shell_dir = config_dir / "quickshell/caelestia"
     if local_shell_dir.exists():
         print("\nLocal copy of shell found:")
+        if (local_shell_dir / ".git").exists():
+            try:
+                shell_ver = subprocess.check_output(
+                    [
+                        "git",
+                        "--git-dir",
+                        local_shell_dir / ".git",
+                        "rev-list",
+                        "--format=%B",
+                        "--max-count=1",
+                        "upstream/main",
+                    ],
+                    text=True,
+                    stderr=subprocess.DEVNULL,
+                )
+                print("    Last merged upstream commit:", shell_ver.split()[1])
+                print("    Commit message:", *shell_ver.splitlines()[1:])
+            except subprocess.CalledProcessError:
+                print("    Unable to determine last merged upstream commit.")
 
-        try:
-            shell_ver = subprocess.check_output(
-                [
-                    "git",
-                    "--git-dir",
-                    local_shell_dir / ".git",
-                    "rev-list",
-                    "--format=%B",
-                    "--max-count=1",
-                    "upstream/main",
-                ],
-                text=True,
-                stderr=subprocess.DEVNULL,
-            )
-            print("    Last merged upstream commit:", shell_ver.split()[1])
-            print("    Commit message:", *shell_ver.splitlines()[1:])
-        except subprocess.CalledProcessError:
-            print("    Unable to determine last merged upstream commit.")
-
-        shell_ver = subprocess.check_output(
-            ["git", "--git-dir", local_shell_dir / ".git", "rev-list", "--format=%B", "--max-count=1", "HEAD"],
-            text=True,
-        )
-        print("\n    Last commit:", shell_ver.split()[1])
-        print("    Commit message:", *shell_ver.splitlines()[1:])
+            try:
+                shell_ver = subprocess.check_output(
+                    ["git", "--git-dir", local_shell_dir / ".git", "rev-list", "--format=%B", "--max-count=1", "HEAD"],
+                    text=True,
+                )
+                print("\n    Last commit:", shell_ver.split()[1])
+                print("    Commit message:", *shell_ver.splitlines()[1:])
+            except subprocess.CalledProcessError:
+                print("\n    Unable to determine last commit.")
+        else:
+            print("    Not a git repository.")


### PR DESCRIPTION
Check if .git directory exists before running git commands on the local shell copy, and wrap the last commit check in a try-except block to prevent CalledProcessError crash when the config folder is not a git repository.