### PR TITLE
fix: remove broken fade-in animation from Thunar GTK theme template

### DIFF
--- a/src/caelestia/data/templates/thunar.css
+++ b/src/caelestia/data/templates/thunar.css
@@ -46,9 +46,6 @@
     margin: 10px 15px 0 0;
     border-radius: 15px;
     background-color: {{ $surfaceContainerLow }};
-    animation: fading 400ms ease forwards;
-    opacity: 0;
-    animation-delay: 250ms;
 }
 
 .thunar .frame.standard-view .view:not(.rubberband),
@@ -98,9 +95,6 @@
 .thunar .sidebar {
     padding: 0 20px;
     background: none;
-    animation: fading 600ms ease forwards;
-    animation-delay: 100ms;
-    opacity: 0;
 }
 
 .thunar .sidebar .view {
@@ -188,15 +182,4 @@
 
 .thunar box.vertical .image {
     margin: 15px;
-}
-
-
-/* =============================================================================
-   Animation
-   ============================================================================= */
-
-@keyframes fading {
-    to {
-        opacity: 1;
-    }
 }


### PR DESCRIPTION
The `.thunar .frame.standard-view` and `.thunar .sidebar` rules used a CSS animation (opacity: 0 -> 1 via @keyframes fading) to fade in on load. On native Wayland, GTK3 fails to trigger this animation's initial frame, leaving both elements permanently at opacity: 0 - making the file view and sidebar fully invisible while still interactive.
<img width="2461" height="1552" alt="image" src="https://github.com/user-attachments/assets/5096e5e2-1863-4a1d-b11e-4d10ceceb5d7" />

