### PR TITLE
perf: use `status` instead of `systeminfo` for lua checking

### DIFF
--- a/src/caelestia/utils/hypr.py
+++ b/src/caelestia/utils/hypr.py
@@ -32,7 +32,7 @@ def is_lua_config() -> bool:
     if _lua_config_cache is not None:
         return _lua_config_cache
     try:
-        result = message("systeminfo", is_json=False)
+        result = message("status", is_json=False)
         for line in result.splitlines():
             if "configProvider:" in line:
                 _lua_config_cache = "lua" in line.lower()


### PR DESCRIPTION
This PR resolves an issue where certain systems will freeze momentarily while running `hyprctl systeminfo`, as described by multiple users in [this](https://discord.com/channels/1459365181317709856/1518069400811606016) helpdesk post from the Discord.

`systeminfo` outputs a ton of information we don't need:
```
danny@halos $ hyprctl systeminfo
Hyprland 0.55.4 built from branch v0.55.4 at commit 

...

os-release: NAME="Arch Linux"
PRETTY_NAME="Arch Linux"
ID=arch
BUILD_ID=rolling
ANSI_COLOR="38;2;23;147;209"
HOME_URL="https://archlinux.org/"
DOCUMENTATION_URL="https://wiki.archlinux.org/"
SUPPORT_URL="https://bbs.archlinux.org/"
BUG_REPORT_URL="https://gitlab.archlinux.org/groups/archlinux/-/issues"
PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
LOGO=archlinux-logo

...

State:

configProvider: lua
backend: drm
```

While `status` outputs almost exclusively what we need:
```
danny@halos $ hyprctl status

configProvider: lua
backend: drm

```