### PR TITLE
fix: Update regex to allow negative coordinates in region

### DIFF
--- a/src/caelestia/subcommands/record.py
+++ b/src/caelestia/subcommands/record.py
@@ -44,7 +44,7 @@ class Command:
                 region = self.args.region.strip()
             args += ["region", "-region", region]
 
-            m = re.match(r"(\d+)x(\d+)\+(\d+)\+(\d+)", region)
+            m = re.match(r"(\d+)x(\d+)\+(-?\d+)\+(-?\d+)", region)
             if not m:
                 raise ValueError(f"Invalid region: {region}")
 


### PR DESCRIPTION
External monitors can sometimes have negative coords. I believe this regex should fix that.