### PR TITLE
fix(utils): update version command to properly detect new and legacy dotfiles installations

### DIFF
--- a/src/caelestia/utils/dots/legacy.py
+++ b/src/caelestia/utils/dots/legacy.py
@@ -25,8 +25,10 @@ _confs = [
 
 def _find_legacy_repo(path: Path) -> Path | None:
     try:
-        remote = subprocess.check_output(["git", "-C", path, "remote", "get-url", "origin"], text=True)
-    except subprocess.CalledProcessError:
+        remote = subprocess.check_output(
+            ["git", "-C", path, "remote", "get-url", "origin"], text=True, stderr=subprocess.DEVNULL
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return
 
     # Check remote

--- a/src/caelestia/utils/dots/packages.py
+++ b/src/caelestia/utils/dots/packages.py
@@ -15,26 +15,6 @@ class PackageError(Exception):
     """Raised when a package operation (install/remove/build/update) fails."""
 
 
-def query_installed_package(package: str) -> tuple[str, str] | None:
-    """Return the installed (name, version) of `package`, resolving provides, or None."""
-
-    if shutil.which("pacman") is None:
-        return None
-
-    result = subprocess.run(
-        ["pacman", "-Q", package],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-    )
-    if result.returncode != 0:
-        return None
-
-    # `pacman -Q` resolves provides and prints "<real name> <version>"
-    parts = result.stdout.split()
-    return (parts[0], parts[1]) if len(parts) >= 2 else None
-
-
 def _try_run(cmd: list[str], error_msg: str, **kwargs) -> None:
     """Run a subprocess, raising `PackageError` if it fails."""
 
@@ -248,19 +228,30 @@ class ArchInstaller(PackageInstaller):
 
         return names
 
-    def _query(self, package: str) -> tuple[str, str] | None:
+    def query(self, package: str) -> tuple[str, str] | None:
         """Return the installed (name, version) of `package`, resolving `provides` (e.g. awk -> gawk), or None."""
 
-        return query_installed_package(package)
+        result = subprocess.run(
+            ["pacman", "-Q", package],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        if result.returncode != 0:
+            return None
+
+        # `pacman -Q` resolves provides and prints "<real name> <version>"
+        parts = result.stdout.split()
+        return (parts[0], parts[1]) if len(parts) >= 2 else None
 
     def _installed_name(self, package: str) -> str:
         """Resolve `package` to its real installed name (handles provides), falling back to the given name."""
 
-        query = self._query(package)
+        query = self.query(package)
         return query[0] if query else package
 
     def installed_version(self, package: str) -> str | None:
-        query = self._query(package)
+        query = self.query(package)
         return query[1] if query else None
 
     def needs_rebuild(self, directory: Path, packages: list[str]) -> bool:

--- a/src/caelestia/utils/dots/packages.py
+++ b/src/caelestia/utils/dots/packages.py
@@ -15,6 +15,26 @@ class PackageError(Exception):
     """Raised when a package operation (install/remove/build/update) fails."""
 
 
+def query_installed_package(package: str) -> tuple[str, str] | None:
+    """Return the installed (name, version) of `package`, resolving provides, or None."""
+
+    if shutil.which("pacman") is None:
+        return None
+
+    result = subprocess.run(
+        ["pacman", "-Q", package],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+
+    # `pacman -Q` resolves provides and prints "<real name> <version>"
+    parts = result.stdout.split()
+    return (parts[0], parts[1]) if len(parts) >= 2 else None
+
+
 def _try_run(cmd: list[str], error_msg: str, **kwargs) -> None:
     """Run a subprocess, raising `PackageError` if it fails."""
 
@@ -231,17 +251,7 @@ class ArchInstaller(PackageInstaller):
     def _query(self, package: str) -> tuple[str, str] | None:
         """Return the installed (name, version) of `package`, resolving `provides` (e.g. awk -> gawk), or None."""
 
-        result = subprocess.run(
-            ["pacman", "-Q", package],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-        if result.returncode != 0:
-            return None
-        # `pacman -Q` resolves provides and prints "<real name> <version>"
-        parts = result.stdout.split()
-        return (parts[0], parts[1]) if len(parts) >= 2 else None
+        return query_installed_package(package)
 
     def _installed_name(self, package: str) -> str:
         """Resolve `package` to its real installed name (handles provides), falling back to the given name."""

--- a/src/caelestia/utils/dots/source.py
+++ b/src/caelestia/utils/dots/source.py
@@ -88,6 +88,11 @@ class DotsSource:
     def manifest_at(self, ref: str) -> Manifest:
         return Manifest.parse(self.text_at(ref, "manifest.toml"))
 
+    def commit_message_at(self, ref: str) -> str:
+        """Return the first line of the commit message at `ref`."""
+
+        return self._git("show", "-s", "--format=%s", ref).strip()
+
     def text_at(self, ref: str, relpath: str) -> str:
         return self._git("show", f"{ref}:{relpath}")
 

--- a/src/caelestia/utils/version.py
+++ b/src/caelestia/utils/version.py
@@ -1,51 +1,88 @@
 import shutil
 import subprocess
+from pathlib import Path
 
+from caelestia.utils.dots.legacy import LEGACY_META_PKG, detect_legacy_repo
+from caelestia.utils.dots.packages import query_installed_package
+from caelestia.utils.dots.source import DotsSource, SourceError
+from caelestia.utils.dots.state import DotsState
 from caelestia.utils.paths import config_dir
 
+PKGS = ("caelestia-shell", "caelestia-cli")
 
-def fetch_git_metadata(repo_dir, branch="upstream/main") -> tuple[str, str] | None:
+
+def fetch_git_metadata(repo_dir: Path, branch: str = "upstream/main") -> tuple[str, str] | None:
     try:
         output = subprocess.check_output(
-            ["git", "-C", repo_dir, "rev-list", "--format=%B", "--max-count=1", branch],
-            text=True,
+            ["git", "-C", repo_dir, "show", "-s", "--format=%H%x00%s", branch],
             stderr=subprocess.DEVNULL,
+            text=True,
         )
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return None
 
-    lines = output.strip().splitlines()
-    return lines[0].split()[1], "".join(lines[1:])
+    commit, separator, message = output.rstrip("\n").partition("\0")
+    return (commit, message) if separator else None
+
+
+def print_packages() -> tuple[str, str] | None:
+    if not shutil.which("pacman"):
+        print("Packages: not on Arch")
+        return None
+
+    print("Packages:")
+    installed = [(pkg, query_installed_package(pkg)) for pkg in PKGS]
+    for pkg, result in installed:
+        if result is None:
+            print(f"    {pkg}: not installed")
+    for _, result in installed:
+        if result is not None:
+            name, version = result
+            print(f"    {name}: {version}")
+
+    return query_installed_package(LEGACY_META_PKG)
+
+
+def print_legacy_install(meta_package: tuple[str, str] | None) -> None:
+    legacy_path = detect_legacy_repo()
+    if legacy_path is None and meta_package is None:
+        return
+
+    print()
+    print("Legacy install detected:")
+    print("    Legacy dots path:", legacy_path or "not found")
+
+    if meta_package is None:
+        print(f"    {LEGACY_META_PKG}: not installed")
+    else:
+        name, version = meta_package
+        print(f"    {name}: {version}")
+    print("    Please update the CLI to the latest version and run 'caelestia install' to update the dots.")
+
+
+def print_caelestia_version() -> None:
+    applied_rev = DotsState.load().applied_rev
+    if applied_rev is None:
+        print("Caelestia: not installed")
+        return
+
+    print("Caelestia:")
+    print("    Last commit:", applied_rev)
+    source = DotsSource()
+    try:
+        message = source.commit_message_at(applied_rev)
+    except (SourceError, FileNotFoundError):
+        print("    Commit message: unavailable")
+    else:
+        print("    Commit message:", message)
 
 
 def print_version() -> None:
-    if shutil.which("pacman"):
-        print("Packages:")
-        pkgs = ["caelestia-shell", "caelestia-cli", "caelestia-meta"]
-        versions = subprocess.run(
-            ["pacman", "-Q", *pkgs], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True
-        ).stdout
-
-        for pkg in pkgs:
-            if pkg not in versions:
-                print(f"    {pkg} not installed")
-        version_lines = versions.splitlines()
-        if version_lines:
-            print("\n".join(f"    {pkg}" for pkg in version_lines))
-    else:
-        print("Packages: not on Arch")
+    meta_package = print_packages()
+    print_legacy_install(meta_package)
 
     print()
-    caelestia_dir = (config_dir / "hypr").resolve().parent
-    caelestia_metadata = fetch_git_metadata(caelestia_dir, "HEAD")
-
-    if caelestia_metadata:
-        commit, message = caelestia_metadata
-        print("Caelestia:")
-        print("    Last commit:", commit)
-        print("    Commit message:", message)
-    else:
-        print("Caelestia: not installed")
+    print_caelestia_version()
 
     print()
     try:

--- a/src/caelestia/utils/version.py
+++ b/src/caelestia/utils/version.py
@@ -81,18 +81,25 @@ def print_legacy_install(meta_package: tuple[str, str] | None) -> None:
 
 
 def print_dots_version() -> None:
-    applied_rev = DotsState.load().applied_rev
-    if applied_rev is None:
+    state = DotsState.load()
+    if state.applied_rev is None:
         _header("Dots:", "not installed")
         return
 
     _header("Dots:")
     source = DotsSource()
     try:
-        message = source.commit_message_at(applied_rev)
+        message = source.commit_message_at(state.applied_rev)
     except (SourceError, FileNotFoundError):
         message = ""
-    _rows([("Commit", _commit(applied_rev, message))])
+    components = ", ".join(state.enabled_components) or "none"
+    _rows(
+        [
+            ("Commit", _commit(state.applied_rev, message)),
+            ("Components", components),
+            ("AUR helper", state.aur_helper),
+        ]
+    )
 
 
 def print_version() -> None:

--- a/src/caelestia/utils/version.py
+++ b/src/caelestia/utils/version.py
@@ -52,7 +52,7 @@ def fetch_git_metadata(repo_dir: Path, branch: str = "upstream/main") -> tuple[s
 
 def print_packages() -> tuple[str, str] | None:
     if not shutil.which("pacman"):
-        print("Packages: not on Arch")
+        _header("Packages:", "not on Arch")
         return None
 
     _header("Packages:")
@@ -97,7 +97,7 @@ def print_dots_version() -> None:
         [
             ("Commit", _commit(state.applied_rev, message)),
             ("Components", components),
-            ("AUR helper", state.aur_helper),
+            ("AUR helper", state.aur_helper if shutil.which("pacman") else "not on Arch"),
         ]
     )
 

--- a/src/caelestia/utils/version.py
+++ b/src/caelestia/utils/version.py
@@ -9,7 +9,7 @@ from caelestia.utils.dots.source import DotsSource, SourceError
 from caelestia.utils.dots.state import DotsState
 from caelestia.utils.paths import config_dir
 
-PKGS = ("caelestia-shell", "caelestia-cli")
+PKGS = ("caelestia-shell", "caelestia-cli", "quickshell")
 INDENT = "    "
 
 

--- a/src/caelestia/utils/version.py
+++ b/src/caelestia/utils/version.py
@@ -21,6 +21,21 @@ def _header(text: str, suffix: str = "") -> None:
         print(f"{text}{suffix}")
 
 
+def _rows(pairs: list[tuple[str, str]], align: bool = False) -> None:
+    dim = sys.stdout.isatty()
+    width = max((len(key) for key, _ in pairs), default=0) if align else 0
+    for key, value in pairs:
+        if dim:
+            value = f"\033[2m{value}\033[0m"
+        label = key.ljust(width) if align else f"{key}:"
+        print(f"{INDENT}{label}  {value}" if align else f"{INDENT}{label} {value}")
+
+
+def _commit(commit: str, message: str) -> str:
+    subject = message.splitlines()[0] if message else ""
+    return f"{commit[:7]} ({subject})"
+
+
 def fetch_git_metadata(repo_dir: Path, branch: str = "upstream/main") -> tuple[str, str] | None:
     try:
         output = subprocess.check_output(
@@ -43,13 +58,9 @@ def print_packages() -> tuple[str, str] | None:
     _header("Packages:")
     installer = ArchInstaller("")  # Dummy helper cause we only use query
     installed = [(pkg, installer.query(pkg)) for pkg in PKGS]
-    for pkg, result in installed:
-        if result is None:
-            print(f"{INDENT}{pkg}: not installed")
-    for _, result in installed:
-        if result is not None:
-            name, version = result
-            print(f"{INDENT}{name}: {version}")
+    missing = [(pkg, "not installed") for pkg, result in installed if result is None]
+    present = [result for _, result in installed if result is not None]
+    _rows(missing + present, align=True)
 
     return installer.query(LEGACY_META_PKG)
 
@@ -61,14 +72,12 @@ def print_legacy_install(meta_package: tuple[str, str] | None) -> None:
 
     print()
     _header("Legacy install detected:")
-    print(f"{INDENT}Legacy dots path: {legacy_path or 'not found'}")
-
-    if meta_package is None:
-        print(f"{INDENT}{LEGACY_META_PKG}: not installed")
-    else:
-        name, version = meta_package
-        print(f"{INDENT}{name}: {version}")
-    print(f"{INDENT}Please update the CLI to the latest version and run 'caelestia install' to update the dots.")
+    meta_row = (LEGACY_META_PKG, "not installed") if meta_package is None else meta_package
+    _rows([("Legacy dots path", str(legacy_path or "not found")), meta_row])
+    update_msg = "Please update the CLI to the latest version and run 'caelestia install' to update the dots."
+    if sys.stdout.isatty():
+        update_msg = f"\033[1m{update_msg}\033[0m"
+    print(f"{INDENT}{update_msg}")
 
 
 def print_dots_version() -> None:
@@ -78,14 +87,12 @@ def print_dots_version() -> None:
         return
 
     _header("Dots:")
-    print(f"{INDENT}Last commit: {applied_rev}")
     source = DotsSource()
     try:
         message = source.commit_message_at(applied_rev)
     except (SourceError, FileNotFoundError):
-        print(f"{INDENT}Commit message: unavailable")
-    else:
-        print(f"{INDENT}Commit message: {message}")
+        message = ""
+    _rows([("Commit", _commit(applied_rev, message))])
 
 
 def print_version() -> None:
@@ -119,13 +126,11 @@ def print_version() -> None:
 
         if upstream_metadata:
             commit, message = upstream_metadata
-            print(f"{INDENT}Last merged upstream commit: {commit}")
-            print(f"{INDENT}Commit message: {message}")
+            _rows([("Last merged upstream commit", _commit(commit, message))])
         else:
             print(f"{INDENT}Unable to determine last merged upstream commit.")
 
         local_metadata = fetch_git_metadata(local_shell_dir, "HEAD")
         if local_metadata:
             commit, message = local_metadata
-            print(f"\n{INDENT}Last local commit: {commit}")
-            print(f"{INDENT}Commit message: {message}")
+            _rows([("Last local commit", _commit(commit, message))])

--- a/src/caelestia/utils/version.py
+++ b/src/caelestia/utils/version.py
@@ -4,6 +4,20 @@ import subprocess
 from caelestia.utils.paths import config_dir
 
 
+def fetch_git_metadata(repo_dir, branch="upstream/main") -> tuple[str, str] | None:
+    try:
+        output = subprocess.check_output(
+            ["git", "-C", repo_dir, "rev-list", "--format=%B", "--max-count=1", branch],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        return None
+
+    lines = output.strip().splitlines()
+    return lines[0].split()[1], "".join(lines[1:])
+
+
 def print_version() -> None:
     if shutil.which("pacman"):
         print("Packages:")
@@ -20,15 +34,15 @@ def print_version() -> None:
         print("Packages: not on Arch")
 
     print()
-    try:
-        caelestia_dir = (config_dir / "hypr").resolve().parent
-        caelestia_ver = subprocess.check_output(
-            ["git", "--git-dir", caelestia_dir / ".git", "rev-list", "--format=%B", "--max-count=1", "HEAD"], text=True
-        )
+    caelestia_dir = (config_dir / "hypr").resolve().parent
+    caelestia_metadata = fetch_git_metadata(caelestia_dir, "HEAD")
+
+    if caelestia_metadata:
+        commit, message = caelestia_metadata
         print("Caelestia:")
-        print("    Last commit:", caelestia_ver.split()[1])
-        print("    Commit message:", *caelestia_ver.splitlines()[1:])
-    except subprocess.CalledProcessError:
+        print("    Last commit:", commit)
+        print("    Commit message:", message)
+    else:
         print("Caelestia: not installed")
 
     print()
@@ -49,29 +63,17 @@ def print_version() -> None:
     local_shell_dir = config_dir / "quickshell/caelestia"
     if local_shell_dir.exists():
         print("\nLocal copy of shell found:")
+        upstream_metadata = fetch_git_metadata(local_shell_dir)
 
-        try:
-            shell_ver = subprocess.check_output(
-                [
-                    "git",
-                    "--git-dir",
-                    local_shell_dir / ".git",
-                    "rev-list",
-                    "--format=%B",
-                    "--max-count=1",
-                    "upstream/main",
-                ],
-                text=True,
-                stderr=subprocess.DEVNULL,
-            )
-            print("    Last merged upstream commit:", shell_ver.split()[1])
-            print("    Commit message:", *shell_ver.splitlines()[1:])
-        except subprocess.CalledProcessError:
+        if upstream_metadata:
+            commit, message = upstream_metadata
+            print("    Last merged upstream commit:", commit)
+            print("    Commit message:", message)
+        else:
             print("    Unable to determine last merged upstream commit.")
 
-        shell_ver = subprocess.check_output(
-            ["git", "--git-dir", local_shell_dir / ".git", "rev-list", "--format=%B", "--max-count=1", "HEAD"],
-            text=True,
-        )
-        print("\n    Last commit:", shell_ver.split()[1])
-        print("    Commit message:", *shell_ver.splitlines()[1:])
+        local_metadata = fetch_git_metadata(local_shell_dir, "HEAD")
+        if local_metadata:
+            commit, message = local_metadata
+            print("\n    Last local commit:", commit)
+            print("    Commit message:", message)

--- a/src/caelestia/utils/version.py
+++ b/src/caelestia/utils/version.py
@@ -29,7 +29,9 @@ def print_version() -> None:
         for pkg in pkgs:
             if pkg not in versions:
                 print(f"    {pkg} not installed")
-        print("\n".join(f"    {pkg}" for pkg in versions.splitlines()))
+        version_lines = versions.splitlines()
+        if version_lines:
+            print("\n".join(f"    {pkg}" for pkg in version_lines))
     else:
         print("Packages: not on Arch")
 

--- a/src/caelestia/utils/version.py
+++ b/src/caelestia/utils/version.py
@@ -3,7 +3,7 @@ import subprocess
 from pathlib import Path
 
 from caelestia.utils.dots.legacy import LEGACY_META_PKG, detect_legacy_repo
-from caelestia.utils.dots.packages import query_installed_package
+from caelestia.utils.dots.packages import ArchInstaller
 from caelestia.utils.dots.source import DotsSource, SourceError
 from caelestia.utils.dots.state import DotsState
 from caelestia.utils.paths import config_dir
@@ -31,7 +31,8 @@ def print_packages() -> tuple[str, str] | None:
         return None
 
     print("Packages:")
-    installed = [(pkg, query_installed_package(pkg)) for pkg in PKGS]
+    installer = ArchInstaller("")  # Dummy helper cause we only use query
+    installed = [(pkg, installer.query(pkg)) for pkg in PKGS]
     for pkg, result in installed:
         if result is None:
             print(f"    {pkg}: not installed")
@@ -40,7 +41,7 @@ def print_packages() -> tuple[str, str] | None:
             name, version = result
             print(f"    {name}: {version}")
 
-    return query_installed_package(LEGACY_META_PKG)
+    return installer.query(LEGACY_META_PKG)
 
 
 def print_legacy_install(meta_package: tuple[str, str] | None) -> None:
@@ -60,13 +61,13 @@ def print_legacy_install(meta_package: tuple[str, str] | None) -> None:
     print("    Please update the CLI to the latest version and run 'caelestia install' to update the dots.")
 
 
-def print_caelestia_version() -> None:
+def print_dots_version() -> None:
     applied_rev = DotsState.load().applied_rev
     if applied_rev is None:
-        print("Caelestia: not installed")
+        print("Dots: not installed")
         return
 
-    print("Caelestia:")
+    print("Dots:")
     print("    Last commit:", applied_rev)
     source = DotsSource()
     try:
@@ -82,7 +83,7 @@ def print_version() -> None:
     print_legacy_install(meta_package)
 
     print()
-    print_caelestia_version()
+    print_dots_version()
 
     print()
     try:

--- a/src/caelestia/utils/version.py
+++ b/src/caelestia/utils/version.py
@@ -32,8 +32,16 @@ def _rows(pairs: list[tuple[str, str]], align: bool = False) -> None:
 
 
 def _commit(commit: str, message: str) -> str:
+    sha = commit[:7]
     subject = message.splitlines()[0] if message else ""
-    return f"{commit[:7]} ({subject})"
+    return f"{sha} ({subject})" if subject else sha
+
+
+def _commit_from_meta(meta: tuple[str, str] | None) -> str:
+    if meta:
+        commit, message = meta
+        return _commit(commit, message)
+    return "unknown"
 
 
 def fetch_git_metadata(repo_dir: Path, branch: str = "upstream/main") -> tuple[str, str] | None:
@@ -130,14 +138,10 @@ def print_version() -> None:
         print()
         _header("Local copy of shell found:")
         upstream_metadata = fetch_git_metadata(local_shell_dir)
-
-        if upstream_metadata:
-            commit, message = upstream_metadata
-            _rows([("Last merged upstream commit", _commit(commit, message))])
-        else:
-            print(f"{INDENT}Unable to determine last merged upstream commit.")
-
         local_metadata = fetch_git_metadata(local_shell_dir, "HEAD")
-        if local_metadata:
-            commit, message = local_metadata
-            _rows([("Last local commit", _commit(commit, message))])
+        _rows(
+            [
+                ("Last merged upstream commit", _commit_from_meta(upstream_metadata)),
+                ("Last local commit", _commit_from_meta(local_metadata)),
+            ]
+        )

--- a/src/caelestia/utils/version.py
+++ b/src/caelestia/utils/version.py
@@ -1,5 +1,6 @@
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 from caelestia.utils.dots.legacy import LEGACY_META_PKG, detect_legacy_repo
@@ -9,6 +10,13 @@ from caelestia.utils.dots.state import DotsState
 from caelestia.utils.paths import config_dir
 
 PKGS = ("caelestia-shell", "caelestia-cli")
+
+
+def _header(text: str) -> None:
+    if sys.stdout.isatty():
+        print(f"\033[1m\033[36m{text}\033[0m")
+    else:
+        print(text)
 
 
 def fetch_git_metadata(repo_dir: Path, branch: str = "upstream/main") -> tuple[str, str] | None:
@@ -30,7 +38,7 @@ def print_packages() -> tuple[str, str] | None:
         print("Packages: not on Arch")
         return None
 
-    print("Packages:")
+    _header("Packages:")
     installer = ArchInstaller("")  # Dummy helper cause we only use query
     installed = [(pkg, installer.query(pkg)) for pkg in PKGS]
     for pkg, result in installed:
@@ -50,7 +58,7 @@ def print_legacy_install(meta_package: tuple[str, str] | None) -> None:
         return
 
     print()
-    print("Legacy install detected:")
+    _header("Legacy install detected:")
     print("    Legacy dots path:", legacy_path or "not found")
 
     if meta_package is None:
@@ -64,10 +72,10 @@ def print_legacy_install(meta_package: tuple[str, str] | None) -> None:
 def print_dots_version() -> None:
     applied_rev = DotsState.load().applied_rev
     if applied_rev is None:
-        print("Dots: not installed")
+        _header("Dots:\033[0m not installed")
         return
 
-    print("Dots:")
+    _header("Dots:")
     print("    Last commit:", applied_rev)
     source = DotsSource()
     try:
@@ -88,21 +96,22 @@ def print_version() -> None:
     print()
     try:
         shell_ver = subprocess.check_output(["/usr/lib/caelestia/version", "-s"], text=True).strip()
-        print("Shell:")
-        print("    ", shell_ver)
+        _header("Shell:")
+        print("   ", shell_ver)
     except FileNotFoundError:
-        print("Shell: version helper not available")
+        _header("Shell:\033[0m version helper not available")
 
     print()
     if shutil.which("qs"):
-        print("Quickshell:")
+        _header("Quickshell:")
         print("   ", subprocess.check_output(["qs", "--version"], text=True).strip())
     else:
-        print("Quickshell: not in PATH")
+        _header("Quickshell:\033[0m not in PATH")
 
     local_shell_dir = config_dir / "quickshell/caelestia"
     if local_shell_dir.exists():
-        print("\nLocal copy of shell found:")
+        print()
+        _header("Local copy of shell found:")
         upstream_metadata = fetch_git_metadata(local_shell_dir)
 
         if upstream_metadata:

--- a/src/caelestia/utils/version.py
+++ b/src/caelestia/utils/version.py
@@ -10,13 +10,15 @@ from caelestia.utils.dots.state import DotsState
 from caelestia.utils.paths import config_dir
 
 PKGS = ("caelestia-shell", "caelestia-cli")
+INDENT = "    "
 
 
-def _header(text: str) -> None:
+def _header(text: str, suffix: str = "") -> None:
+    suffix = f" {suffix}" if suffix else ""
     if sys.stdout.isatty():
-        print(f"\033[1m\033[36m{text}\033[0m")
+        print(f"\033[1;36m{text}\033[0m{suffix}")
     else:
-        print(text)
+        print(f"{text}{suffix}")
 
 
 def fetch_git_metadata(repo_dir: Path, branch: str = "upstream/main") -> tuple[str, str] | None:
@@ -43,11 +45,11 @@ def print_packages() -> tuple[str, str] | None:
     installed = [(pkg, installer.query(pkg)) for pkg in PKGS]
     for pkg, result in installed:
         if result is None:
-            print(f"    {pkg}: not installed")
+            print(f"{INDENT}{pkg}: not installed")
     for _, result in installed:
         if result is not None:
             name, version = result
-            print(f"    {name}: {version}")
+            print(f"{INDENT}{name}: {version}")
 
     return installer.query(LEGACY_META_PKG)
 
@@ -59,31 +61,31 @@ def print_legacy_install(meta_package: tuple[str, str] | None) -> None:
 
     print()
     _header("Legacy install detected:")
-    print("    Legacy dots path:", legacy_path or "not found")
+    print(f"{INDENT}Legacy dots path: {legacy_path or 'not found'}")
 
     if meta_package is None:
-        print(f"    {LEGACY_META_PKG}: not installed")
+        print(f"{INDENT}{LEGACY_META_PKG}: not installed")
     else:
         name, version = meta_package
-        print(f"    {name}: {version}")
-    print("    Please update the CLI to the latest version and run 'caelestia install' to update the dots.")
+        print(f"{INDENT}{name}: {version}")
+    print(f"{INDENT}Please update the CLI to the latest version and run 'caelestia install' to update the dots.")
 
 
 def print_dots_version() -> None:
     applied_rev = DotsState.load().applied_rev
     if applied_rev is None:
-        _header("Dots:\033[0m not installed")
+        _header("Dots:", "not installed")
         return
 
     _header("Dots:")
-    print("    Last commit:", applied_rev)
+    print(f"{INDENT}Last commit: {applied_rev}")
     source = DotsSource()
     try:
         message = source.commit_message_at(applied_rev)
     except (SourceError, FileNotFoundError):
-        print("    Commit message: unavailable")
+        print(f"{INDENT}Commit message: unavailable")
     else:
-        print("    Commit message:", message)
+        print(f"{INDENT}Commit message: {message}")
 
 
 def print_version() -> None:
@@ -97,16 +99,17 @@ def print_version() -> None:
     try:
         shell_ver = subprocess.check_output(["/usr/lib/caelestia/version", "-s"], text=True).strip()
         _header("Shell:")
-        print("   ", shell_ver)
+        print(f"{INDENT}{shell_ver}")
     except FileNotFoundError:
-        _header("Shell:\033[0m version helper not available")
+        _header("Shell:", "version helper not available")
 
     print()
     if shutil.which("qs"):
+        qs_ver = subprocess.check_output(["qs", "--version"], text=True).strip()
         _header("Quickshell:")
-        print("   ", subprocess.check_output(["qs", "--version"], text=True).strip())
+        print(f"{INDENT}{qs_ver}")
     else:
-        _header("Quickshell:\033[0m not in PATH")
+        _header("Quickshell:", "not in PATH")
 
     local_shell_dir = config_dir / "quickshell/caelestia"
     if local_shell_dir.exists():
@@ -116,13 +119,13 @@ def print_version() -> None:
 
         if upstream_metadata:
             commit, message = upstream_metadata
-            print("    Last merged upstream commit:", commit)
-            print("    Commit message:", message)
+            print(f"{INDENT}Last merged upstream commit: {commit}")
+            print(f"{INDENT}Commit message: {message}")
         else:
-            print("    Unable to determine last merged upstream commit.")
+            print(f"{INDENT}Unable to determine last merged upstream commit.")
 
         local_metadata = fetch_git_metadata(local_shell_dir, "HEAD")
         if local_metadata:
             commit, message = local_metadata
-            print("\n    Last local commit:", commit)
-            print("    Commit message:", message)
+            print(f"\n{INDENT}Last local commit: {commit}")
+            print(f"{INDENT}Commit message: {message}")


### PR DESCRIPTION
## Summary

- utilize new and existing helpers from `src/caelestia/utils/dots/` for querying installed packages, legacy repo paths, and git revisions
- add a shared helper for reading Git commit metadata in `caelestia -v`
- suppress Git stderr and treat failed metadata lookups as unavailable
- prevent `caelestia -v` from printing fatal Git errors when config directories or local shell copies are unavailable/not git repositories
- implement detection for legacy installations of the dotfiles via querying for the `caelestia-meta` package and checking legacy paths, showing a new "legacy install" section and instructing the user on how to update the dots

Closes #114, handles the same issue present in the PR and extends it to the other git repository checks.

## Testing

- Python build/install succeeds
- `caelesita -v` functions correctly and displays necessary data properly
  - legacy section appears when `calestia-meta`, legacy dots paths, or both are present
  - legacy section is not shown when all legacy detection methods return nothing
  - git checks no longer leak stderr into version command output
  - functionally-unchanged behavior continues to operate as expected

### Previous output

```
danny@halos $ caelestia -v
Packages:
    caelestia-shell: 2.0.2-1
    caelestia-cli: 1.1.0-1
    caelestia-meta 1.0-1

fatal: not a git repository: '/home/danny/.config/.git'
Caelestia: not installed

Shell:
     caelestia-shell 2.0.2, revision 90ba3617b0d00a1efc23370e3cb6c08db23b8c92, distributed by: Unset

Quickshell:
    Quickshell 0.3.0 (revision 7d1c9a9c6721606b129829134d6f614f015621e2, distributed by AUR (package: quickshell-git))

Local copy of shell found:
    Last merged upstream commit: 2b5eb204b267f1568666de83438798cca59fdcd1
    Commit message: [CI] chore: update flake 

    Last commit: 85056a362776acbd068ed745fe76a47a5abe926e
    Commit message: style: optimize imports 
    
 ```
 
 ### Updated output with legacy install
 
 ```
danny@halos $ caelestia -v
Packages:
    caelestia-shell: 2.2.0-1
    caelestia-cli: 1.1.0-1

Legacy install detected:
    Legacy dots path: /home/danny/.local/share/caelestia
    caelestia-meta: 1.0-1
    Please update the CLI to the latest version and run 'caelestia install' to update the dots.

Caelestia: not installed

Shell:
     caelestia-shell 2.2.0, revision 5cb94e43eb3506dd9253aaafd86e9794cd4505b1, distributed by: direnv

Quickshell:
    Quickshell 0.3.0 (revision e649d247498512464457aefcd05b73038c4e65a1, distributed by AUR (package: quickshell-git))

Local copy of shell found:
    Last merged upstream commit: ecfb8221c82cb97e3b12cf032a3d3843821d6c5d
    Commit message: refactor: change IP-lookup API + handle retry on rate limited (#1734)

    Last local commit: 5cb94e43eb3506dd9253aaafd86e9794cd4505b1
    Commit message: fix(icons): prevent literal "undefined" in fallback icon
```

### Updated output without legacy install

```
danny@halos $ caelestia -v
Packages:
    caelestia-shell: 2.2.0-1
    caelestia-cli: 1.1.0-1
    
Caelestia: not installed

Shell:
     caelestia-shell 2.2.0, revision 5cb94e43eb3506dd9253aaafd86e9794cd4505b1, distributed by: direnv

Quickshell:
    Quickshell 0.3.0 (revision e649d247498512464457aefcd05b73038c4e65a1, distributed by AUR (package: quickshell-git))

Local copy of shell found:
    Last merged upstream commit: ecfb8221c82cb97e3b12cf032a3d3843821d6c5d
    Commit message: refactor: change IP-lookup API + handle retry on rate limited (#1734)

    Last local commit: 5cb94e43eb3506dd9253aaafd86e9794cd4505b1
    Commit message: fix(icons): prevent literal "undefined" in fallback icon
```