### PR TITLE
feat(scheme): support # prefix for hex colors in schemes

### DIFF
--- a/src/caelestia/utils/scheme.py
+++ b/src/caelestia/utils/scheme.py
@@ -201,7 +201,10 @@ scheme: Scheme | None = None
 
 
 def read_colours_from_file(path: Path) -> dict[str, str]:
-    return {k.strip(): v.strip() for k, v in (line.split(" ") for line in path.read_text().splitlines() if line)}
+    return {
+        k.strip(): v.strip().removeprefix("#")
+        for k, v in (line.split(" ") for line in path.read_text().splitlines() if line)
+    }
 
 
 def get_scheme_path() -> Path:


### PR DESCRIPTION
## Summary

Supports hex colors prefixed by `#` (e.g., `#123456`) in scheme files by stripping the leading prefix.